### PR TITLE
Optimize the parsing of special floats: infinity and nan.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -153,5 +153,27 @@ func BenchmarkParseFloat64Special(b *testing.B) {
 			{inp: "-inf", out: math.Inf(-1)},
 		})
 	})
+}
 
+func BenchmarkParseFloat32Special(b *testing.B) {
+	b.Run("strconv", func(b *testing.B) {
+		benchmarkParseFloat32(b, strconv.ParseFloat, []float32String{
+			{inp: "NaN", out: float32(math.NaN())},
+			{inp: "nan", out: float32(math.NaN())},
+			{inp: "Inf", out: float32(math.Inf(1))},
+			{inp: "inf", out: float32(math.Inf(1))},
+			{inp: "+Infinity", out: float32(math.Inf(1))},
+			{inp: "-inf", out: float32(math.Inf(-1))},
+		})
+	})
+	b.Run("refloat", func(b *testing.B) {
+		benchmarkParseFloat32(b, refloat.ParseFloat, []float32String{
+			{inp: "NaN", out: float32(math.NaN())},
+			{inp: "nan", out: float32(math.NaN())},
+			{inp: "Inf", out: float32(math.Inf(1))},
+			{inp: "inf", out: float32(math.Inf(1))},
+			{inp: "+Infinity", out: float32(math.Inf(1))},
+			{inp: "-inf", out: float32(math.Inf(-1))},
+		})
+	})
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -131,3 +131,27 @@ func BenchmarkParseFloat32(b *testing.B) {
 		benchmarkParseFloat32(b, refloat.ParseFloat, randnorm32)
 	})
 }
+
+func BenchmarkParseFloat64Special(b *testing.B) {
+	b.Run("strconv", func(b *testing.B) {
+		benchmarkParseFloat64(b, strconv.ParseFloat, []float64String{
+			{inp: "NaN", out: math.NaN()},
+			{inp: "nan", out: math.NaN()},
+			{inp: "Inf", out: math.Inf(1)},
+			{inp: "inf", out: math.Inf(1)},
+			{inp: "+Infinity", out: math.Inf(1)},
+			{inp: "-inf", out: math.Inf(-1)},
+		})
+	})
+	b.Run("refloat", func(b *testing.B) {
+		benchmarkParseFloat64(b, refloat.ParseFloat, []float64String{
+			{inp: "NaN", out: math.NaN()},
+			{inp: "nan", out: math.NaN()},
+			{inp: "Inf", out: math.Inf(1)},
+			{inp: "inf", out: math.Inf(1)},
+			{inp: "+Infinity", out: math.Inf(1)},
+			{inp: "-inf", out: math.Inf(-1)},
+		})
+	})
+
+}

--- a/float32.go
+++ b/float32.go
@@ -36,18 +36,22 @@ func parseFloat32(num string) (float32, int, error) {
 
 	if offset >= len(num) {
 		return 0, 0, errorSyntax(fnc, num)
-	} else if num[offset]|0x20 == 'i' {
-		comm := common(num[offset:], "infinity")
-		if comm >= 8 {
+	}
+
+	if num[offset]|0x20 == 'i' {
+		comm := common(num[offset+1:], "nfinity")
+		if comm == 7 {
 			return math.Float32frombits(inf32 | uint32(sign)<<31), offset + 8, nil
 		}
-		if comm >= 3 {
+		if comm == 2 {
 			return math.Float32frombits(inf32 | uint32(sign)<<31), offset + 3, nil
 		}
 		return 0, 0, errorSyntax(fnc, num)
-	} else if num[offset]|0x20 == 'n' {
-		comm := common(num[offset:], "nan")
-		if comm >= 3 && offset == 0 {
+	}
+
+	if num[offset]|0x20 == 'n' {
+		comm := common(num[offset+1:], "an")
+		if comm == 2 && offset == 0 {
 			return math.Float32frombits(nan32), offset + 3, nil
 		}
 		return 0, 0, errorSyntax(fnc, num)

--- a/float64.go
+++ b/float64.go
@@ -33,23 +33,26 @@ func parseFloat64(num string) (float64, int, error) {
 		sign = 1
 	}
 
-	// ORing 0x20 gives lowercased characters.
 	if offset >= len(num) {
 		return 0, 0, errorSyntax(fnc, num)
-	} else if num[offset]|0x20 == 'i' {
-		comm := common(num[offset:], "infinity")
-		if comm >= 8 {
+	}
+	// ORing 0x20 gives lowercased characters.
+	if num[offset]|0x20 == 'i' {
+		comm := common(num[offset+1:], "nfinity")
+		if comm == 7 {
 			return math.Inf(-sign), offset + 8, nil
 		}
 		// don't consume something like "infin" more than "inf".
-		if comm >= 3 {
+		if comm == 2 {
 			return math.Inf(-sign), offset + 3, nil
 		}
 		return 0, 0, errorSyntax(fnc, num)
-	} else if num[offset]|0x20 == 'n' {
-		comm := common(num[offset:], "nan")
+	}
+
+	if num[offset]|0x20 == 'n' {
+		comm := common(num[offset+1:], "an")
 		// NaN cannot be signed.
-		if comm >= 3 && offset == 0 {
+		if comm == 2 && offset == 0 {
 			return math.NaN(), offset + 3, nil
 		}
 		return 0, 0, errorSyntax(fnc, num)

--- a/refloat_test.go
+++ b/refloat_test.go
@@ -113,6 +113,9 @@ var atoftests = []atofTest{
 	{"nan", "NaN", nil},
 	{"NaN", "NaN", nil},
 	{"NAN", "NaN", nil},
+	{"-nan", "0", ErrSyntax},
+	{"+nan", "0", ErrSyntax},
+	{"NaNny", "0", ErrSyntax},
 
 	// Infs
 	{"inf", "+Inf", nil},
@@ -121,6 +124,8 @@ var atoftests = []atofTest{
 	{"-Infinity", "-Inf", nil},
 	{"+INFINITY", "+Inf", nil},
 	{"Infinity", "+Inf", nil},
+	{"-infini", "0", ErrSyntax},
+	{"infinityy", "0", ErrSyntax},
 
 	// largest float64
 	{"1.7976931348623157e308", "1.7976931348623157e+308", nil},


### PR DESCRIPTION
Don't repeat the check on the first character in each string: 'i' or 'n'. Add a benchmark for special floats.
Supplement units test on special floats with SyntaxError cases.

Benchmarks on my M1 Mac show a -8% speedup:

$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/sugawarayuuta/refloat
                               │   old.txt   │              new.txt              │
                               │   sec/op    │   sec/op     vs base              │
ParseFloat64Special/refloat-10   8.895n ± 1%   8.197n ± 1%  -7.84% (p=0.002 n=6)